### PR TITLE
Feature/add script auto generate missing metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,32 @@ print(newARB);
 */
 ```
 
-#### Bin script
+#### Bin scripts
+
+Please run
+
+```sh
+dart pub global activate arb_utils
+```
+
+to enable arb_utils to be globally activated.
+
+##### Sort
 
 To easily sort an arb and update original file, use
 
 ```sh
-dart run arb_utils:sort <INPUT FILE>
+pub global run arb_utils:sort <INPUT FILE>
 ```
 
-where `<INPUT FILE>` is a path to the input file: `dart run arb_utils:sort example/test.arb`
+where `<INPUT FILE>` is a path to the input file.
+
+##### Add Missing Default Metadata
+
+To easily add missing metadata to an arb and update original file, use
+
+```sh
+pub global run arb_utils:generate_meta <INPUT FILE>
+```
+
+where `<INPUT FILE>` is a path to the input file.

--- a/bin/generate_meta.dart
+++ b/bin/generate_meta.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:arb_utils/arb_utils.dart';
+
+void main(List<String> args) async {
+  if (args.isEmpty) {
+    print('ERROR! Expected filepath to arb file.');
+    exit(0);
+  } else if (args.length > 1) {
+    print('WARNING! Ignoring excess arguments ${args.sublist(1)}');
+  }
+
+  final file = File(args.first);
+  if (!await file.exists()) {
+    print('ERROR! File ${file.path} does not exists');
+    exit(0);
+  }
+
+  var arbContents = await file.readAsString();
+  arbContents = addMissingMetadata(arbContents);
+
+  await file.writeAsString(arbContents);
+}

--- a/bin/sort.dart
+++ b/bin/sort.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:arb_utils/arb_utils.dart';
 
-void main(List<String> args) {
+void main(List<String> args) async {
   if (args.isEmpty) {
     print('ERROR! Expected filepath to arb file.');
     exit(0);
@@ -11,13 +11,13 @@ void main(List<String> args) {
   }
 
   final file = File(args.first);
-  if (!file.existsSync()) {
-    print('ERROR! File ${args.first} does not exists');
+  if (!await file.exists()) {
+    print('ERROR! File ${file.path} does not exists');
     exit(0);
   }
 
-  final arbContents = file.readAsStringSync();
-  final sortedContents = sortARB(arbContents);
+  var arbContents = await file.readAsString();
+  arbContents = sortARB(arbContents);
 
-  file.writeAsStringSync(sortedContents);
+  await file.writeAsString(arbContents);
 }

--- a/lib/arb_utils.dart
+++ b/lib/arb_utils.dart
@@ -1,7 +1,8 @@
 /// A library with tools for handling .arb files
 library arb_utils;
 
-export 'src/primitives/merge.dart';
+export 'src/primitives/add_missing_metadata.dart';
 export 'src/primitives/diff.dart';
+export 'src/primitives/merge.dart';
 export 'src/primitives/sort.dart';
 export 'src/utils/process_new_keys.dart';

--- a/lib/src/primitives/add_missing_metadata.dart
+++ b/lib/src/primitives/add_missing_metadata.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+
+/// Adds any missing default metadata for keys
+///
+/// Note that the resulting output is not sorted
+String addMissingMetadata(String arbContents) {
+  final Map<String, dynamic> contents = json.decode(arbContents);
+  final keys = contents.keys.where((key) => !key.startsWith('@')).toList();
+
+  for (final key in keys) {
+    if (!contents.containsKey('@$key')) {
+      contents['@$key'] = _defaultMetadata;
+    }
+  }
+
+  final encoder = JsonEncoder.withIndent('  ');
+  return encoder.convert(contents);
+}
+
+const Map<String, dynamic> _defaultMetadata = {};

--- a/test/primitives/add_missing_metadata_test.dart
+++ b/test/primitives/add_missing_metadata_test.dart
@@ -1,0 +1,57 @@
+import 'package:arb_utils/src/primitives/add_missing_metadata.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('addMissingMetadata', () {
+    test('Given an arb where some keys have no metadata, expect metadata added', () {
+      const arb = '''{
+  "@@locale": "en",
+  "myKey": "Hello world!",
+  "welcome": "Welcome {firstName}!",
+  "@welcome": {
+    "description": "A welcome message"
+  }
+}''';
+
+      const expectedValue = '''{
+  "@@locale": "en",
+  "myKey": "Hello world!",
+  "welcome": "Welcome {firstName}!",
+  "@welcome": {
+    "description": "A welcome message"
+  },
+  "@myKey": {}
+}''';
+
+      expect(addMissingMetadata(arb), expectedValue);
+    });
+
+    test('Given an arb where all keys have metadata, expect no changes', () {
+      const arb = '''{
+  "@@locale": "en",
+  "myKey": "Hello world!",
+  "@myKey": {
+    "description": "The conventional newborn programmer greeting"
+  },
+  "welcome": "Welcome {firstName}!",
+  "@welcome": {
+    "description": "A welcome message"
+  }
+}''';
+
+      expect(addMissingMetadata(arb), arb);
+    });
+
+    test('Given a non-valid arb, expect exception raised', () {
+      const arb = '''{
+  "@@locale": "en",
+  "myKey": "Hello world!",
+}''';
+
+      expect(
+        () => addMissingMetadata(arb),
+        throwsFormatException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
* Add ability to autogenerate missing default metadata. This is especially useful for base language ARBs.
* Update sort script to be async instead of sync. Maybe this isn't needed but could avoid issues when sort and generate_meta scripts are used together.
