### PR TITLE
Feature Request: custom sort function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Feature add: sortARB() can take a custom sort function and add 3 flags for sorting options in bin script sort
+
 ## 0.0.3
 
 - Feature add: Add missingMetadata (James from DeFunc Art made the PR)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,38 @@ will be converted to:
 }
 ```
 
+You could also provide a custom sort function.
+
+```dart
+var arb1 = '''
+{
+    "clave":"valor",
+    "@clave":{
+        "description": "Descripcion"
+    },
+    "key":"value",
+    "@key":{
+        "description": "Description"
+    }
+}''';
+var sortedArb1 = sortARB(arb1, (a, b) => a[1].compareTo(b[1]));
+print(sortedArb1);
+/*
+{
+    "key":"value",
+    "@key":{
+        "description": "Description"
+    },
+    "clave":"valor",
+    "@clave":{
+        "description": "Descripcion"
+    }
+}
+*/
+```
+
 #### diffARBs
-Will generate a .arb formatted string with the keys that doesn't appear in both the provided .arb formmated arguments
+Will generate a .arb formatted string with the keys that doesn't appear in both the provided .arb formatted arguments
 ```dart
 var arb1 = '''
 {
@@ -223,6 +253,18 @@ pub global run arb_utils:sort <INPUT FILE>
 ```
 
 where `<INPUT FILE>` is a path to the input file.
+
+Also, there are 3 flags for different sorting.
+
+--case-insensitive / -c
+--natural-ordering / -n
+--descending / -d
+
+For example, to sort with case insensitive and in descending order, use
+
+```sh
+pub global run arb_utils:sort -c -d <INPUT FILE>
+```
 
 ##### Add Missing Default Metadata
 

--- a/bin/sort.dart
+++ b/bin/sort.dart
@@ -1,23 +1,56 @@
 import 'dart:io';
 
 import 'package:arb_utils/arb_utils.dart';
+import 'package:args/args.dart';
+import 'package:collection/collection.dart';
+
+const String caseInsensitive = 'case-insensitive';
+const String naturalOrdering = 'natural-ordering';
+const String descending = 'descending';
 
 void main(List<String> args) async {
-  if (args.isEmpty) {
+  var parser = ArgParser();
+  parser.addFlag(caseInsensitive, abbr: 'c');
+  parser.addFlag(naturalOrdering, abbr: 'n');
+  parser.addFlag(descending, abbr: 'd');
+  var result = parser.parse(args);
+  if (result.rest.isEmpty) {
     print('ERROR! Expected filepath to arb file.');
     exit(0);
-  } else if (args.length > 1) {
-    print('WARNING! Ignoring excess arguments ${args.sublist(1)}');
+  } else if (result.rest.length > 1) {
+    print('WARNING! Ignoring excess arguments ${result.rest.sublist(1)}');
   }
 
-  final file = File(args.first);
+  final file = File(result.rest.first);
   if (!await file.exists()) {
     print('ERROR! File ${file.path} does not exists');
     exit(0);
   }
 
   var arbContents = await file.readAsString();
-  arbContents = sortARB(arbContents);
+  arbContents = sortARB(
+    arbContents,
+    (A, B) => sort(A, B, result[caseInsensitive], result[naturalOrdering],
+        result[descending]),
+  );
 
   await file.writeAsString(arbContents);
+}
+
+int sort(String A, String B, bool isCaseInsensitive, bool isNaturalOrdering,
+    bool isDescending) {
+  var ascending = 1;
+  if (isDescending) {
+    ascending = -1;
+  }
+  if (isCaseInsensitive) {
+    A = A.toLowerCase();
+    B = B.toLowerCase();
+  }
+
+  if (isNaturalOrdering) {
+    return ascending * compareNatural(A, B);
+  } else {
+    return ascending * A.compareTo(B);
+  }
 }

--- a/lib/src/primitives/sort.dart
+++ b/lib/src/primitives/sort.dart
@@ -2,17 +2,18 @@ import 'dart:convert';
 
 /// Sorts the .arb formatted String `arbContents` in alphabetically order
 /// of the keys, with the @key portion added below it's respective key
-String sortARB(String arbContents) {
+String sortARB(String arbContents,
+    [int Function(String, String) compare = Comparable.compare]) {
   final sorted = <String, dynamic>{};
   final Map<String, dynamic> contents = json.decode(arbContents);
 
   final keys = contents.keys.where((key) => !key.startsWith('@')).toList()
-    ..sort();
+    ..sort(compare);
 
   // Add at the beginning the [Global Attributes] of the .arb original file, if any
   // [link]: https://github.com/google/app-resource-bundle/wiki/ApplicationResourceBundleSpecification#global-attributes
   contents.keys.where((key) => key.startsWith('@@')).toList()
-    ..sort()
+    ..sort(compare)
     ..forEach((key) {
       sorted[key] = contents[key];
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arb_utils
 description: A set of tools to work with .arb files (the preferred Dart way of dealing with i18n/l10n/translations)
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/Rodsevich/arb_utils
 homepage: https://gitlab.com/Rodsevich/arb_utils
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,7 @@ environment:
 #  path: ^1.7.0
 
 dev_dependencies:
+  args: ^2.1.1
+  collection: ^1.15.0
   pedantic: ^1.11.0
   test: ^1.17.3


### PR DESCRIPTION
update sortARB to take an optional custom sort function

I do not sure whether there are any methods to allow bin script to take a custom function,
so, I just add 3 flags to provide some common sort options in bin script sort
--case-insensitive / -c
--natural-ordering / -n
--descending / -d

test data:
```
{
  "@zKey2": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey11": {
    "description": "simple description"
  }
}
```
run the above data by following commands:

dart bin/sort.dart l10n/intl_en.arb
```
{
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -c l10n/intl_en.arb
```
{
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -d l10n/intl_en.arb
```
{
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -n l10n/intl_en.arb
```
{
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -c -d l10n/intl_en.arb
```
{
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -c -n l10n/intl_en.arb
```
{
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  },
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -d -n l10n/intl_en.arb
```
{
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  }
}
```
dart bin/sort.dart -c -d -n l10n/intl_en.arb
```
{
  "zKey11": "a simple key",
  "@zKey11": {
    "description": "simple description"
  },
  "zKey2": "a simple key",
  "@zKey2": {
    "description": "simple description"
  },
  "zKey1": "a simple key",
  "@zKey1": {
    "description": "simple description"
  },
  "zKey": "a simple key",
  "@zKey": {
    "description": "simple description"
  },
  "ZKey": "a simple key",
  "@ZKey": {
    "description": "simple description"
  },
  "aKey": "a simple key",
  "@aKey": {
    "description": "simple description"
  }
}
```