### PR TITLE
Move locale.dart export to arb_utils_flutter

### DIFF
--- a/lib/arb_utils.dart
+++ b/lib/arb_utils.dart
@@ -6,5 +6,4 @@ export 'src/primitives/add_missing_metadata.dart';
 export 'src/primitives/diff.dart';
 export 'src/primitives/merge.dart';
 export 'src/primitives/sort.dart';
-export 'src/utils/locale.dart';
 export 'src/utils/process_new_keys.dart';

--- a/lib/arb_utils_flutter.dart
+++ b/lib/arb_utils_flutter.dart
@@ -1,1 +1,2 @@
+export 'src/utils/locale.dart';
 export 'src/widgets/language_selector_dropdown.dart';


### PR DESCRIPTION
When included as part of arb_utils.dart, arb_utils could no longer be used as a standalone script with `dart pub global activate arb_utils` and `dart pub run arb_utils:sort`.

Fixes #6 

I don't know if this is the appropriate fix, but it seems to work for me for my purposes. I don't use the flutter widget, so I didn't test that, but I did run the tests.