### PR TITLE
Replace flutter lints with dart lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/lib/src/arb_client.dart
+++ b/lib/src/arb_client.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
-import 'package:intl/intl.dart';
-import 'package:intl_utils/src/parser/icu_parser.dart';
-import 'package:intl_utils/src/parser/message_format.dart';
 import 'package:collection/collection.dart';
+import 'package:intl/intl.dart';
+import 'package:intl_utils/src/parser/icu_parser.dart'; // ignore: implementation_imports
+import 'package:intl_utils/src/parser/message_format.dart'; // ignore: implementation_imports
 
 typedef MissingKeyDefaultValue = String Function(String key);
 typedef MissingKeyCallback = void Function(String key);
@@ -25,12 +25,12 @@ class ArbClient {
       MissingKeyCallback? onMissingKeyCallback,
       bool? exceptionOnMissingKey,
       MissingKeyDefaultValue? onMissingKeyDefaultValue})
-      : this.onMissingKeyCallback = (onMissingKeyCallback ??
+      : onMissingKeyCallback = (onMissingKeyCallback ??
             (String key) {
               print('ARB key not found: $key');
             }),
-        this.exceptionOnMissingKey = exceptionOnMissingKey ?? false,
-        this.onMissingKeyDefaultValue =
+        exceptionOnMissingKey = exceptionOnMissingKey ?? false,
+        onMissingKeyDefaultValue =
             (onMissingKeyDefaultValue ?? (key) => 'value of $key') {
     reloadArb(arbSource, locale: locale);
   }
@@ -39,8 +39,8 @@ class ArbClient {
   String get arbSource => _arbSource;
 
   void reloadArb(String arbSource, {String? locale}) {
-    this._arbSource = arbSource;
-    this._arbJson = json.decode(arbSource);
+    _arbSource = arbSource;
+    _arbJson = json.decode(arbSource);
     if (_arbJson.containsKey('@@locale')) {
       this.locale = _arbJson['@@locale'];
     } else if (locale != null) {
@@ -150,6 +150,7 @@ class ArbClient {
 }
 
 class ArbClientExceptionNoLocale implements Exception {
+  @override
   String toString() =>
       'No @@locale key found in the arb source nor locale provided. '
       'The locale is needed for the translation logic, please provide one.';
@@ -162,6 +163,7 @@ class ArbClientExceptionNoKey implements Exception {
   /// Thrown when `key` was searched but not found in the arb file.
   const ArbClientExceptionNoKey(this.key, [this.arguments = const {}]);
 
+  @override
   String toString() =>
       'Exception: ARB key not found: $key' +
       (arguments.isNotEmpty ? '($arguments)' : '');
@@ -174,6 +176,7 @@ class ArbClientExceptionNoArgument implements Exception {
   /// Thrown when `key` requires an argument for being translated but that wasn't provided
   const ArbClientExceptionNoArgument(this.key, this.arbValue);
 
+  @override
   String toString() => 'Exception: ARB argument not provided: $key ($arbValue)';
 }
 
@@ -184,6 +187,7 @@ class ArbClientExceptionMalformedValue implements Exception {
   /// Thrown when `key` references an ARB value that is not ICU-compliant
   const ArbClientExceptionMalformedValue(this.key, this.value);
 
+  @override
   String toString() =>
       "ArbClientException: ARB key '$key' points to a malformed value: $value";
 }

--- a/lib/src/commands/generate_meta.dart
+++ b/lib/src/commands/generate_meta.dart
@@ -25,6 +25,7 @@ class GenerateMetaCommand extends Command {
         defaultsTo: false);
   }
 
+  @override
   FutureOr<void> run() async {
     final args = argResults!.rest;
 

--- a/lib/src/commands/sort.dart
+++ b/lib/src/commands/sort.dart
@@ -35,6 +35,7 @@ class SortCommand extends Command {
         defaultsTo: false);
   }
 
+  @override
   FutureOr<void> run() async {
     if (argResults!.rest.isEmpty) {
       print(red('ERROR! Expected filepath to arb file.'));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -304,14 +304,14 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -8,7 +8,7 @@ void main() {
     var finalContents = '';
     var output = <String>[];
 
-    void run_command(String command) {
+    void runCommand(String command) {
       final initialBuffer = StringBuffer();
       final finalBuffer = StringBuffer();
       read(sampleArbFile).forEach((line) {
@@ -30,12 +30,12 @@ void main() {
     });
 
     test('fails on unknown command', () async {
-      run_command('dart bin/arb_utils.dart unknown');
+      runCommand('dart bin/arb_utils.dart unknown');
       expect(
           output.first, contains('Could not find a command named "unknown".'));
     });
     test('generates the metadata', () async {
-      run_command('dart bin/arb_utils.dart generate-meta $sampleArbFile');
+      runCommand('dart bin/arb_utils.dart generate-meta $sampleArbFile');
       expect(initialContents, isNot(contains('"@noMetadataKey": {}')));
       expect(finalContents, contains('"@noMetadataKey": {}'));
     });

--- a/test/primitives/sort_test.dart
+++ b/test/primitives/sort_test.dart
@@ -1,5 +1,4 @@
 import 'package:arb_utils/arb_utils.dart';
-import 'package:test/scaffolding.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -235,7 +234,8 @@ void main() {
     "description": "simple description"
   }
 }''';
-      expect(sortARB(original, descendingOrdering: true, caseInsensitive: true), expected);
+      expect(sortARB(original, descendingOrdering: true, caseInsensitive: true),
+          expected);
     });
     test('case insensitive + natural ordering sorting', () {
       const expected = '''{
@@ -264,7 +264,8 @@ void main() {
     "description": "simple description"
   }
 }''';
-      expect(sortARB(original, caseInsensitive: true, naturalOrdering: true), expected);
+      expect(sortARB(original, caseInsensitive: true, naturalOrdering: true),
+          expected);
     });
     test('descending + natural ordering sorting', () {
       const expected = '''{
@@ -293,7 +294,8 @@ void main() {
     "description": "simple description"
   }
 }''';
-      expect(sortARB(original, descendingOrdering: true, naturalOrdering: true), expected);
+      expect(sortARB(original, descendingOrdering: true, naturalOrdering: true),
+          expected);
     });
     test('case insensitive + natural ordering + descending sorting', () {
       const expected = '''{
@@ -322,7 +324,12 @@ void main() {
     "description": "simple description"
   }
 }''';
-      expect(sortARB(original, caseInsensitive: true, naturalOrdering: true, descendingOrdering: true), expected);
+      expect(
+          sortARB(original,
+              caseInsensitive: true,
+              naturalOrdering: true,
+              descendingOrdering: true),
+          expected);
     });
   });
 }


### PR DESCRIPTION
`flutter_lints` wasn't in the `pubspec.yaml`, so they weren't working anyway. But, on top of that, Flutter lints specialize in a Flutter app where things like print statements aren't common. The dart lints are probably more appropriate for a CLI.