### PR TITLE
build: pin dart_console2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.0
+ - Switch "dcli" to stable version and constraint dependency of "dart_console2" for fixing [#26](https://github.com/Rodsevich/arb_utils/issues/26) 
+
 ## 0.7.1
  - bump version of dcli for fixing [#23](https://github.com/Rodsevich/arb_utils/issues/23)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,11 +15,13 @@ dependencies:
   intl: ^0.18.0
   intl_utils: ^2.8.7
   shared_preferences: ^2.2.2
-  dcli: ^4.0.1-alpha.4
+  dcli: ^3.4.0
 
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.25.2
+  # pin dependency to avoid internal errors in dcli
+  dart_console2: 3.0.0
 
 executables:
   arb_utils:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,12 +16,11 @@ dependencies:
   intl_utils: ^2.8.7
   shared_preferences: ^2.2.2
   dcli: ^3.4.0
+  dart_console2: <3.1.0 # constraint dependency to avoid internal errors in dcli
 
 dev_dependencies:
   lints: ^3.0.0
   test: ^1.25.2
-  # pin dependency to avoid internal errors in dcli
-  dart_console2: 3.0.0
 
 executables:
   arb_utils:


### PR DESCRIPTION
## Overview

Fixes #26

Due to internal errors caused by dart_console2 version 3.1.0 and higher, pin the version. Since dcli also leads to internal errors, switch to the latest stable version.