### PR TITLE
Remove the unused dart_console dependency & allow dcli v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.11.1
+
+- Removed unused dart_console dependency.
+
 ## 0.11.0
 
 - Added improved `add` command with human-friendly and JSON template syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.1
 
 - Removed unused dart_console dependency.
+- Added support for dcli v9.
 
 ## 0.11.0
 
@@ -19,7 +20,6 @@
 ## 0.10.0
 
 - Solved issue with default locale in null
-
 
 ## 0.9.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arb_utils
 description: A set of tools to work with .arb files (the preferred Dart way of dealing with i18n/l10n/translations)
-version: 0.11.0
+version: 0.11.1
 repository: https://github.com/Rodsevich/arb_utils
 homepage: https://gitlab.com/Rodsevich/arb_utils
 
@@ -16,7 +16,6 @@ dependencies:
   intl_utils: ^2.8.7
   shared_preferences: ^2.2.2
   dcli: ">=6.0.0 <=9.0.0"
-  dart_console: ^4.1.0
 
 dev_dependencies:
   lints: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,12 +15,11 @@ dependencies:
   intl: ">=0.18.0 <0.21.0"
   intl_utils: ^2.8.7
   shared_preferences: ^2.2.2
-  dcli: ">=6.0.0 <=9.0.0"
+  dcli: ">=6.0.0 <=10.0.0"
 
 dev_dependencies:
   lints: ^4.0.0
   test: ^1.25.2
-  win32: ^5.4.0
 
 executables:
   arb_utils:


### PR DESCRIPTION
dart_console uses win32 < 6.0.0 which blocs some of my dependency updates.